### PR TITLE
ACKspace: Fixed CORS problem due to Apache redirect

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -1,7 +1,7 @@
 {
   "\/dev\/tal":"http:\/\/www.devtal.de\/api\/",
   "57North Hacklab":"http:\/\/57north.co\/spaceapi",
-  "ACKspace":"https:\/\/ackspace.nl\/spaceAPI",
+  "ACKspace":"https:\/\/ackspace.nl\/spaceAPI\/",
   "AFRA":"http:\/\/geruempel.ddns.net\/status.json",
   "Ace Monster Toys":"http:\/\/acemonstertoys.org\/status.json",
   "Apollo-NG":"https:\/\/apollo.open-resource.org\/status.php",


### PR DESCRIPTION
Upon playing with a web app, came to the conclusion that the (presumable) Apache `DirectorySlash` directive causes a `301` which makes `XMLHttpRequest` fail to see the (correct) `Access-Control-Allow-Origin` and `Content-Type` headers.