### PR TITLE
Adding the Chaostreff Bern

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -24,6 +24,7 @@
   "Chaosconsulting":"http:\/\/chaos-consulting.de\/api\/space.api",
   "Chaosdorf":"https:\/\/chaosdorf.de\/space_api.json",
   "Chaospott":"http:\/\/status.chaospott.de\/status.json",
+  "Chaostreff Bern":"https:\/\/www.chaosbern.ch\/spaceapi.json",
   "Chaostreff Chemnitz":"https:\/\/chaoschemnitz.de\/chch.json",
   "Chaostreff-Dortmund":"http:\/\/status.ctdo.de\/api\/spaceapi\/v13",
   "Chaostreff Recklinghausen c3RE":"http:\/\/doorstatus.c3re.de\/status\/json",


### PR DESCRIPTION
The Chaostreff Bern is not so much a hackerspace as more a fixed location for the Chaostreff Bern to hold their meetings, presentations and workshops. It's a nice location and you should definitely come by some time to visit us!