### PR TITLE
weinhof9 → verschwoerhaus (+https)

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -147,7 +147,7 @@
   "sublab":"http://sublab.org/status.json",
   "syn2cat":"https://level2.lu/spaceapi/",
   "turmlabor":"http://www.turmlabor.de/spaces.api",
+  "verschwoerhaus":"https://verschwoerhaus.de/feed/spaceapi",
   "vspace.one":"https://vspace.one/spaceapi.json",
-  "weinhof9":"http://weinhof9.de/?feed=spaceapi",
   "xHain":"https://x-hain.de/spaceapi-0.13.json"
 }


### PR DESCRIPTION
verschwoerhaus is the official name for some time now and we've switched to https